### PR TITLE
Fix: pools retry

### DIFF
--- a/app/http.php
+++ b/app/http.php
@@ -84,6 +84,9 @@ $registry->set('pool', function () {
         };
     });
 
+    $pool->setRetrySleep(1); // in seconds
+    $pool->setRetryAttempts(30);
+
     return $pool;
 });
 


### PR DESCRIPTION
In coroutine style server, we arent scared of long-runnign requests.
Instead of dropping request, we give it more time to wait for available connection. This will cause long response times instead of instant 4XX / 5XX errors.